### PR TITLE
feat: Add sticky header and move metadata to modal

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,8 +6,13 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ onSubmitClick }) => {
   return (
-    <header className="relative py-8 sm:py-12 border-b border-gray-700/50">
-      <div className="absolute right-4 top-4">
+    <header className="sticky-header bg-gray-900 py-4 border-b border-gray-700/50">
+      <div className="container mx-auto px-4 flex justify-between items-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold tracking-tighter text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-cyan-400">
+            SkipTheDocs
+          </h1>
+        </div>
         <button
           onClick={onSubmitClick}
           className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-500 transition-colors flex items-center gap-2"
@@ -17,14 +22,6 @@ const Header: React.FC<HeaderProps> = ({ onSubmitClick }) => {
           </svg>
           Submit Config
         </button>
-      </div>
-      <div className="text-center">
-        <h1 className="text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tighter text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 to-cyan-400">
-          SkipTheDocs
-        </h1>
-        <p className="mt-3 text-lg sm:text-xl max-w-2xl mx-auto text-gray-400">
-          The ultimate database for your development tool configurations.
-        </p>
       </div>
     </header>
   );

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -64,6 +64,17 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, config, onDownload, titl
               <div>
                 <h2 className="text-xl font-bold text-gray-100">{config.toolName}</h2>
                 <p className="text-sm text-indigo-400 font-mono">{config.fileName}</p>
+                <div className="text-xs text-gray-400 mt-1">
+                  <span>Author: {config.author}</span> | <span>Version: {config.version}</span>
+                  {config.repositoryUrl && (
+                    <>
+                      {' | '}
+                      <a href={config.repositoryUrl} target="_blank" rel="noopener noreferrer" className="text-indigo-400 hover:underline">
+                        GitHub
+                      </a>
+                    </>
+                  )}
+                </div>
               </div>
               <button onClick={onClose} className="p-2 rounded-full text-gray-400 hover:text-white hover:bg-gray-700 transition-colors" aria-label="Close modal">
                 <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/index.css
+++ b/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.sticky-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+}

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,5 +1,6 @@
 {
   "name": "SkipTheDocs",
   "description": "A searchable database of high-quality configuration files for various development tools. Find and customize configs for Neovim, Tmux, Zsh, and more.",
+  "githubUrl": "https://github.com/theblackcat98/SkipTheDocs",
   "requestFramePermissions": []
 }


### PR DESCRIPTION
- Adds a sticky header to the application.
- Moves the 'Submit Config' button to the header.
- Displays the config metadata (author, version, GitHub link) in the modal.